### PR TITLE
Optimize query when using dimension tables

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: BiocDuckDB
 Version: 0.5.5
-Date: 2025-01-29
+Date: 2025-01-30
 Title: Bioconductor DuckDB Bindings
 Description:
     This package provides bindings for DuckDB tables that extend Bioconductor


### PR DESCRIPTION
Using set complement filter when it is more performant than the original filter