### PR TITLE
fix: improve sparse matrix handling and array extraction

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: BiocDuckDB
-Version: 0.5.17
-Date: 2025-04-25
+Version: 0.5.18
+Date: 2025-05-02
 Title: Bioconductor DuckDB Bindings
 Description:
     This package provides bindings for DuckDB tables that extend Bioconductor

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -194,6 +194,7 @@ checkDuckDBMatrix <- function(object, expected) {
     expect_identical(dim(object), dim(expected))
     expect_identical(dimnames(object), dimnames(expected))
     expect_equal(as.matrix(object), expected)
+    expect_equal(as(object, "CsparseMatrix"), as(expected, "CsparseMatrix"))
 }
 
 checkDuckDBDataFrame <- function(object, expected) {


### PR DESCRIPTION
- Fix array extraction by properly handling key columns and matrix indexing
- Improve sparse array extraction with type checking and fallback
- Update fill value initialization to use vector() for better type handling
- Add CsparseMatrix comparison in test suite
- Bump version to 0.5.18